### PR TITLE
Fix JS immersion link

### DIFF
--- a/source/partials/javascriptimmersion.html.erb
+++ b/source/partials/javascriptimmersion.html.erb
@@ -4,7 +4,7 @@ See the file license.txt for copying permission. -->
 
 <!-- JavaScript class info -->
 <div class="row jumbotron">
-  <% link_to "/javascript.html" do %>
+  <% link_to "/javascriptimmersion.html" do %>
     <%= image_tag "jsi.png", :class=>"img-responsive centered" %>
   <% end %>
 


### PR DESCRIPTION
Fixes incorrect image link in the JS Immersion partial to point to the right detail page.
